### PR TITLE
Updated MigratingBlobStore to use a queue

### DIFF
--- a/src/main/java/org/hashsplit4j/store/MigratingBlobStore.java
+++ b/src/main/java/org/hashsplit4j/store/MigratingBlobStore.java
@@ -1,33 +1,41 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package org.hashsplit4j.store;
 
-import org.hashsplit4j.api.ReceivingBlobStore;
-import org.hashsplit4j.api.PushingBlobStore;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.hashsplit4j.api.BlobImpl;
 import org.hashsplit4j.api.BlobStore;
+import org.slf4j.LoggerFactory;
 
 /**
  *
  * @author dylan
  */
-public class MigratingBlobStore implements BlobStore{
-    
+public class MigratingBlobStore implements BlobStore {
+
+    private static final org.slf4j.Logger log = LoggerFactory.getLogger(MigratingBlobStore.class);
+
     private final BlobStore newBlobStore;
     private final BlobStore oldBlobStore;
+    private final ExecutorService exService;
+    private final ScheduledExecutorService scheduleService;
+    private final BlockingQueue<BlobImpl> queue = new ArrayBlockingQueue<>(1000);
+    private final QueueMonitorRunnable monitor;
     
-    public MigratingBlobStore(BlobStore newBlobStore, BlobStore oldBlobStore){
+    private Future<?> blobQueue = null;
+
+    public MigratingBlobStore(BlobStore newBlobStore, BlobStore oldBlobStore) {
         this.newBlobStore = newBlobStore;
         this.oldBlobStore = oldBlobStore;
-        if(oldBlobStore instanceof PushingBlobStore){
-            PushingBlobStore pBlobStore = (PushingBlobStore) oldBlobStore;
-            if(newBlobStore instanceof ReceivingBlobStore){
-                ReceivingBlobStore rBlobStore = (ReceivingBlobStore) newBlobStore;
-                pBlobStore.setReceivingBlobStore(rBlobStore);
-            }
-        }
+
+        exService = Executors.newCachedThreadPool();
+        scheduleService = Executors.newScheduledThreadPool(5); // 5 Threads max
+        monitor = new QueueMonitorRunnable();
+        scheduleService.scheduleAtFixedRate(monitor, 30, 30, TimeUnit.SECONDS);
     }
 
     @Override
@@ -37,11 +45,14 @@ public class MigratingBlobStore implements BlobStore{
 
     @Override
     public byte[] getBlob(String hash) {
-        if(newBlobStore.hasBlob(hash)){
+        log.info("getBlob={}", hash);
+        if (newBlobStore.hasBlob(hash)) {
+            log.info("got blob from={}", newBlobStore);
             return newBlobStore.getBlob(hash);
-        }else if(oldBlobStore.hasBlob(hash)){
-            byte [] data = oldBlobStore.getBlob(hash);
-            newBlobStore.setBlob(hash, data);
+        } else if (oldBlobStore.hasBlob(hash)) {
+            log.info("got blob from={}", oldBlobStore);
+            byte[] data = oldBlobStore.getBlob(hash);
+            enqueue(hash, data);
             return data;
         }
         return null;
@@ -51,5 +62,47 @@ public class MigratingBlobStore implements BlobStore{
     public boolean hasBlob(String hash) {
         return newBlobStore.hasBlob(hash) || oldBlobStore.hasBlob(hash);
     }
-    
+
+    private void enqueue(String hash, byte[] bytes) {
+        log.info("Enqueuing blob={}", hash);
+        BlobImpl blob = new BlobImpl(hash, bytes);
+        queue.offer(blob);
+    }
+
+    public class BlobQueueRunnable implements Runnable {
+
+        private final BlobStore blobStore;
+
+        public BlobQueueRunnable(BlobStore blobStore) {
+            this.blobStore = blobStore;
+        }
+
+        @Override
+        public void run() {
+            try {
+                BlobImpl blob = queue.take();
+                while (true) {
+                    if (blob != null) {
+                        blobStore.setBlob(blob.getHash(), blob.getBytes());
+                    }
+                    blob = queue.take();
+                }
+            } catch (InterruptedException ex) {
+                log.error("Exception inserting blob into store:" + blobStore, ex);
+                throw new RuntimeException(ex);
+            }
+        }
+
+    }
+
+    public class QueueMonitorRunnable implements Runnable {
+
+        @Override
+        public void run() {
+            if (blobQueue == null || blobQueue.isCancelled() || blobQueue.isDone()) {
+                BlobQueueRunnable r = new BlobQueueRunnable(newBlobStore);
+                blobQueue = exService.submit(r);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Using a queueing system in MigratingBlobStore instead of pushing the blobs in the same transaction when not found on the new blob store